### PR TITLE
Added 'Also Look In Subfolders' option for 'Use All Files In A Folder'

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+v1.2.2
+- Add "Also Look In Subfolders" option for "Use All Files In A Folder"
+
 v1.2.1
 - Add option to shutdown after the screensaver is automatically stopped
 

--- a/resources/language/English (US)/strings.po
+++ b/resources/language/English (US)/strings.po
@@ -96,6 +96,10 @@ msgctxt "#32031"
 msgid "Schedule Settings File"
 msgstr "Schedule Settings File"
 
+msgctxt "#32032"
+msgid "Also Look In Subfolders"
+msgstr "Also Look In Subfolders"
+
 msgctxt "#32050"
 msgid "Set/Download Preset Video File"
 msgstr "Set/Download Preset Video File"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,9 +5,10 @@
 		<setting id="displaySelected" label="32022" subsetting="true" visible="eq(-1,0)" enable="false" type="text" default="- Not Set -"/>
 		<setting label="32050" subsetting="true" visible="eq(-2,0)" type="action" option="close" action="RunScript($CWD/download.py)"/>
 		<setting id="useFolder" subsetting="true" visible="eq(-3,1)" type="bool" label="32023" default="false"/>
-		<setting id="screensaverFile" label="32051" subsetting="true" visible="eq(-4,1) + eq(-1,false)" type="video"/>
-		<setting id="screensaverFolder" label="32054" subsetting="true" visible="eq(-5,1) + eq(-2,true)" type="folder"/>
-		<setting id="folderRepeatType" subsetting="true" visible="eq(-6,1) + eq(-3,true)" type="enum" label="32024" lvalues="32025|32026" default="0"/>
+		<setting id="recurseFolders" subsetting="true" visible="eq(-1,true)" type="bool" label="32032" default="false"/>
+		<setting id="screensaverFile" label="32051" subsetting="true" visible="eq(-5,1) + eq(-2,false)" type="video"/>
+		<setting id="screensaverFolder" label="32054" subsetting="true" visible="eq(-6,1) + eq(-3,true)" type="folder"/>
+		<setting id="folderRepeatType" subsetting="true" visible="eq(-7,1) + eq(-4,true)" type="enum" label="32024" lvalues="32025|32026" default="0"/>
 		<setting id="overlayImage" type="enum" label="32200" lvalues="32202|32204|32205|32206|32203" default="0"/>
 		<setting id="overlayImageFile" label="32201" subsetting="true" visible="eq(-1,4)" type="image"/>
     	<setting label="32002" type="lsep"/>

--- a/screensaver.py
+++ b/screensaver.py
@@ -219,14 +219,14 @@ class ScreensaverWindow(xbmcgui.WindowXMLDialog):
             # Check if we are dealing with a Folder of videos
             if videosFolder != "" and dir_exists(videosFolder):
                 self.currentScheduleItem = -1
-                dirs, files = list_dir(videosFolder)
+                recursive = Settings.isFolderSelectionRecursive()
+                dirs, files = list_dir(videosFolder, recursive)
                 # Now shuffle the playlist to ensure that if there are more
                 #  than one video a different one starts each time
                 random.shuffle(files)
                 for vidFile in files:
-                    fullPath = os_path_join(videosFolder, vidFile)
-                    log("Screensaver video in directory is: %s" % fullPath)
-                    playlist.add(fullPath)
+                    log("Screensaver video in directory is: %s" % vidFile)
+                    playlist.add(vidFile)
         else:
             # Must be dealing with a single file
             videoFile = Settings.getScreensaverVideo()


### PR DESCRIPTION
Hi Rob,

For my own use, I created the extra option to recurse down subfolders when you select the user-defined video selection and you choose to use "all files in a folder". I tested the changes (did also some basic regression testing) and all seems to be fine.

At a high-level, the changes are:
* Added a new bool setting to enable/disable folder recursion (default: false)
* Added language string to English (US) language file for setting in question. **Note**: I haven't added the string to any other language file.
* Added code in settings.py and screensaver.py to handle recursion if selected.
* Added entry to changelog.txt.

Feel free to pull if you find it generally useful.

Best regards,

Guido